### PR TITLE
Allow labels to be created for private repos

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,7 +261,7 @@ function* get_repos(org) {
   // handle github pagination for orgs with many repos
   while (++page) {
     var res = yield request({
-        uri    : 'https://api.github.com/users/' + org + '/repos?page=' + page
+        uri    : 'https://api.github.com/orgs/' + org + '/repos?page=' + page
       , headers: header
       , auth   : this.auth
       , json   : true


### PR DESCRIPTION
From my testing it appears that when you use the users endpoint, GH will only return public repos irregardless of your token privilege. If you change this to use orgs endpoint, then it will also add the private repos to your list of repos to be modified.

Hope you find this useful, I did.
